### PR TITLE
feat: add support for require in the first position of a function call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "babel-plugin-lazy-require",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Transform CommonJS require statements into lazily evaluated imports",
   "main": "index.js",
   "scripts": {
-    "test": "nyc babel test --plugins ../index.js --out-dir test-dist",
+    "test": "nyc babel test --ignore test/fixtures --plugins ../index.js --out-dir test-dist && diff -b test-dist/sample.js test/fixtures/sample.js",
     "coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "release": "standard-version"
   },

--- a/test/fixtures/sample.js
+++ b/test/fixtures/sample.js
@@ -1,0 +1,107 @@
+const _constGlobalRequire = {
+    initialized: false
+};
+const _letGlobalRequire = {
+    initialized: false
+};
+const _varGlobalRequire = {
+    initialized: false
+};
+const _constWrappedRequire = {
+    initialized: false
+};
+const _nonglobalRequire = {
+    initialized: false
+};
+const _imports = {
+    get constGlobalRequire() {
+        if (!_constGlobalRequire.initialized) {
+            _constGlobalRequire.value = require('const-global-require');
+            _constGlobalRequire.initialized = true;
+        }
+
+        return _constGlobalRequire.value;
+    },
+
+    get letGlobalRequire() {
+        if (!_letGlobalRequire.initialized) {
+            _letGlobalRequire.value = require('let-global-require');
+            _letGlobalRequire.initialized = true;
+        }
+
+        return _letGlobalRequire.value;
+    },
+
+    set letGlobalRequire(value) {
+        if (!_letGlobalRequire.initialized) {
+            require('let-global-require');
+
+            _letGlobalRequire.initialized = true;
+        }
+
+        _letGlobalRequire.value = value;
+    },
+
+    get varGlobalRequire() {
+        if (!_varGlobalRequire.initialized) {
+            _varGlobalRequire.value = require('var-global-require');
+            _varGlobalRequire.initialized = true;
+        }
+
+        return _varGlobalRequire.value;
+    },
+
+    set varGlobalRequire(value) {
+        if (!_varGlobalRequire.initialized) {
+            require('var-global-require');
+
+            _varGlobalRequire.initialized = true;
+        }
+
+        _varGlobalRequire.value = value;
+    },
+
+    get constWrappedRequire() {
+        if (!_constWrappedRequire.initialized) {
+            _constWrappedRequire.value = noop(require('const-wrapped-require'));
+            _constWrappedRequire.initialized = true;
+        }
+
+        return _constWrappedRequire.value;
+    },
+
+    get nonglobalRequire() {
+        if (!_nonglobalRequire.initialized) {
+            _nonglobalRequire.value = require('nonglobal-require');
+            _nonglobalRequire.initialized = true;
+        }
+
+        return _nonglobalRequire.value;
+    }
+
+};
+
+require('static-require');
+
+const constWrappedRequireWithArgs = noop(require('const-wrapped-require'), 'data');
+
+const obj = {
+    letGlobalRequire: () => {
+        function varGlobalRequire() {
+
+            _imports.constGlobalRequire.prop = 5;
+            _imports.letGlobalRequire = {};
+            const varGlobalRequire = {
+                foo: '13'
+            };
+            try {
+                obj.constGlobalRequire = _imports.varGlobalRequire;
+            } catch (letGlobalRequire) {}
+        }
+
+        class constGlobalRequire {
+            letGlobalRequire() {}
+        }
+    },
+    varGlobalRequire() {}
+};

--- a/test/sample.js
+++ b/test/sample.js
@@ -2,6 +2,8 @@ const constGlobalRequire = require('const-global-require');
 let letGlobalRequire = require('let-global-require');
 var varGlobalRequire = require('var-global-require');
 require('static-require');
+const constWrappedRequire = noop(require('const-wrapped-require'));
+const constWrappedRequireWithArgs = noop(require('const-wrapped-require'), 'data');
 
 const obj = {
     letGlobalRequire: () => {


### PR DESCRIPTION
The base repository for [babel-plugin-lazy-require](https://github.com/princjef/babel-plugin-lazy-require) does not modify the following input:
```javascript
const noop = x => x
const stuff = noop(require('stuff'))
```

This is problematic because `@babel/preset-env` likes to do things like this:
```javascript
var stuff = _interopRequireWildcard(require('stuff'));
```

It would be very cool if this library transformed that into this:
```javascript
const _imports = {
    get someModule() {
        if (!_someModule.initialized) {
            _someModule.value = _interopRequireWildcard(require('stuff'));
            _someModule.initialized = true;
        }
        return _someModule.value;
    }
}
```