### PR TITLE
fix: include wrapper in setter

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ exports.default = function ({ types: t }) {
                         t.ifStatement(
                             t.unaryExpression('!', initializedMember),
                             t.blockStatement([
-                                t.expressionStatement(requireExpression),
+                                t.expressionStatement(requireExpressionWithOuterFunc),
                                 t.expressionStatement(t.assignmentExpression('=', initializedMember, t.booleanLiteral(true)))
                             ])
                         ),

--- a/test/fixtures/sample.js
+++ b/test/fixtures/sample.js
@@ -10,6 +10,9 @@ const _varGlobalRequire = {
 const _constWrappedRequire = {
     initialized: false
 };
+const _letWrappedRequire = {
+    initialized: false
+};
 const _nonglobalRequire = {
     initialized: false
 };
@@ -68,6 +71,24 @@ const _imports = {
         }
 
         return _constWrappedRequire.value;
+    },
+
+    get letWrappedRequire() {
+        if (!_letWrappedRequire.initialized) {
+            _letWrappedRequire.value = noop(require("let-wrapped-require"));
+            _letWrappedRequire.initialized = true;
+        }
+
+        return _letWrappedRequire.value;
+    },
+
+    set letWrappedRequire(value) {
+        if (!_letWrappedRequire.initialized) {
+            noop(require("let-wrapped-require"));
+            _letWrappedRequire.initialized = true;
+        }
+
+        _letWrappedRequire.value = value;
     },
 
     get nonglobalRequire() {

--- a/test/sample.js
+++ b/test/sample.js
@@ -3,6 +3,7 @@ let letGlobalRequire = require('let-global-require');
 var varGlobalRequire = require('var-global-require');
 require('static-require');
 const constWrappedRequire = noop(require('const-wrapped-require'));
+let letWrappedRequire = noop(require('let-wrapped-require'));
 const constWrappedRequireWithArgs = noop(require('const-wrapped-require'), 'data');
 
 const obj = {


### PR DESCRIPTION
For a wrapped `require` call that assigns to `let`, we should include the wrapping function inside the setter.