### PR TITLE
fix: look for binding in ancestor scopes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
     - lts/*
-    - node
+# node 19 is broken
+# see https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/8
+#    - node
 os: linux
 dist: focal
 arch: arm64

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ exports.default = function ({ types: t }) {
             // If a binding is found, but either isn't derived from the same
             // scope as our requires or isn't in our declarations map, we
             // can't do anything with it
-            const binding = path.scope.bindings[path.node.name];
+            const binding = path.scope.getBinding(path.node.name);
             if (binding && binding.scope !== this.requireScope) {
                 return;
             }

--- a/test/fixtures/sample.js
+++ b/test/fixtures/sample.js
@@ -152,31 +152,41 @@ const [destructuredItem] = require('const-global-destructured-array');
 
 const obj = {
     letGlobalRequire: () => {
+        _imports.constGlobalRequire.prop = 5;
+
+        fns[_imports.constGlobalRequire]();
+
+        _imports.letGlobalRequire = {};
+
+        try {
+            obj.constGlobalRequire = _imports.varGlobalRequire;
+        } catch (letGlobalRequire) {}
+
+        _imports.destructured();
+
+        _imports.destructuredAfterRename();
+
+        closure2(letWrappedRequire => {
+            closure1(() => {
+                letWrappedRequire();
+            });
+        });
+    },
+
+    varGlobalRequire() {
         function varGlobalRequire() {
-            _imports.constGlobalRequire.prop = 5;
-
-            fns[_imports.constGlobalRequire]();
-
-            _imports.letGlobalRequire = {};
             const varGlobalRequire = {
                 foo: '13'
             };
-
-            try {
-                obj.constGlobalRequire = _imports.varGlobalRequire;
-            } catch (letGlobalRequire) {}
-
-            _imports.destructured();
-
-            _imports.destructuredAfterRename();
+            const x = varGlobalRequire;
         }
+
+        const x = varGlobalRequire;
 
         class constGlobalRequire {
             letGlobalRequire() {}
 
         }
-    },
-
-    varGlobalRequire() {}
+    }
 
 };

--- a/test/sample.js
+++ b/test/sample.js
@@ -10,25 +10,33 @@ const [ destructuredItem ] = require('const-global-destructured-array');
 
 const obj = {
     letGlobalRequire: () => {
-        function varGlobalRequire() {
-            const nonglobalRequire = require('nonglobal-require');
+        const nonglobalRequire = require('nonglobal-require');
 
-            constGlobalRequire.prop = 5;
-            fns[constGlobalRequire]()
-            letGlobalRequire = {};
+        constGlobalRequire.prop = 5;
+        fns[constGlobalRequire]()
+        letGlobalRequire = {};
+        try {
+            obj.constGlobalRequire = varGlobalRequire;
+        } catch (letGlobalRequire) { }
+        destructured();
+        destructuredAfterRename();
+
+        closure2(letWrappedRequire => {
+            closure1(() => {
+                letWrappedRequire()
+            })
+        })
+    },
+    varGlobalRequire() {
+        function varGlobalRequire() {
             const varGlobalRequire = {
                 foo: '13'
-            };
-            try {
-                obj.constGlobalRequire = varGlobalRequire;
-            } catch (letGlobalRequire) { }
-            destructured();
-            destructuredAfterRename();
+            }
+            const x = varGlobalRequire
         }
-
+        const x = varGlobalRequire
         class constGlobalRequire {
-            letGlobalRequire() { }
+            letGlobalRequire() {}
         }
-    },
-    varGlobalRequire() { }
+    }
 }


### PR DESCRIPTION
This PR changes `scope.getOwnBinding` to `scope.getBinding` to account for ancestor scopes.